### PR TITLE
chore: add `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "simmerjs": "^0.5.6"
   },
   "devDependencies": {
-    "chromedriver": "^86.0.0",
+    "chromedriver": "^89.0.0",
     "eslint": "^6.5.1",
     "kcd-scripts": "^5.0.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Since this library is already using `dependabot-preview`, let's use the newest Dependabot version