### PR TITLE
chore(deps): Bump nightwatch dependency to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   "dependencies": {
     "@babel/runtime": "^7.4.3",
     "@testing-library/dom": "^7.0.4",
-    "nightwatch": "^1.2.4",
+    "nightwatch": "^2.0.7",
     "simmerjs": "^0.5.6"
   },
   "devDependencies": {
-    "chromedriver": "^89.0.0",
+    "chromedriver": "^98.0.1",
     "eslint": "^6.5.1",
     "kcd-scripts": "^5.0.0",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Nightwatch v1 has vulnerabilities, including `ansi-regex`.
bump the dependency to v2.

Also bumped chromedriver dev dependency.
